### PR TITLE
mark Backport extensions as deprecated, not obsoleted

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,3 +68,34 @@ jobs:
 
       - name: Build with Swift 5 language mode
         run: swift build -Xswiftc -swift-version -Xswiftc 5
+  
+  test-xcode-26-macos26:
+    name: Xcode 26 (macOS 26) / Swift 6 & 5
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.0.1.app/Contents/Developer
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Show Swift version
+        run: swift --version
+
+      - name: Build with Swift 6 language mode
+        run: swift build
+
+      - name: Run tests
+        run: swift test
+
+      - name: Build for iOS Simulator
+        run: |
+          xcodebuild build \
+            -scheme Helpers \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -skipPackagePluginValidation
+
+      - name: Build with Swift 5 language mode
+        run: swift build -Xswiftc -swift-version -Xswiftc 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           xcodebuild build \
             -scheme Helpers \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,name=iPhone 17' \
             -skipPackagePluginValidation
 
       - name: Build with Swift 5 language mode

--- a/Sources/Helpers/Variadic.swift
+++ b/Sources/Helpers/Variadic.swift
@@ -35,11 +35,11 @@ public extension View {
     }
 }
 
-@available(iOS, introduced: 13, obsoleted: 18)
-@available(macOS, introduced: 11, obsoleted: 15)
-@available(tvOS, introduced: 13, obsoleted: 18)
-@available(watchOS, introduced: 8, obsoleted: 11)
-@available(visionOS, introduced: 1, obsoleted: 2)
+@available(iOS, introduced: 13, deprecated: 18)
+@available(macOS, introduced: 11, deprecated: 15)
+@available(tvOS, introduced: 13, deprecated: 18)
+@available(watchOS, introduced: 8, deprecated: 11)
+@available(visionOS, introduced: 1, deprecated: 2)
 public extension Backport where Content == Never {
     @MainActor
     struct SubviewsCollection: RandomAccessCollection {


### PR DESCRIPTION
The helpers fail to build on macOS 26.4 because ob the `@available` attributes that mark the extension as obsoleted. By using "deprecated" instead, the build seems to work.

This might be part of a fix for toastersocks/MultiPicker#12